### PR TITLE
Adiciona github pages via CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: Deploy to GitHub Pages
 on:
   push:
-    branches: ["*"]
+    branches: ["main"]
   workflow_dispatch:
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,15 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches: ["*"]
+  workflow_dispatch:
+jobs:
+  deploy:
+    uses: "getpelican/pelican/.github/workflows/github_pages.yml@main"
+    permissions:
+      contents: "read"
+      pages: "write"
+      id-token: "write"
+    with:
+      settings: "publishconf.py"
+      requirements: "-r requirements.txt"


### PR DESCRIPTION
Testei a CI em `https://itepifanio.github.io/pybr-blog/` e parece estar ok.

Para aceitar esse PR é preciso ir nas configurações de github pages e aceitar deploy via github actions. Também é necessário renomear a branch principal de `master` para `main`